### PR TITLE
make nodemon work w/ socket.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,9 @@ For launching a datastore emulator locally, run `npm run datastore:start`. This 
 
 ## Server
 For testing the server, run `npm run watch`. This will launch the server. It will also restart the server every time a source file changes.
+
+Because of socket.io, we need to kill the server from the command line before restarting it (if using `npm run watch`). nodemon.json contains a command for nodemon to use to restart the server (instead of whatever nodemon does by default).
+
+For this to work, you need to be running Linux and have the `fuser` command installed. You might also need to tweak the delay field for your computer. The higher the delay field, the longer nodemon will wait before restarting the server. This will give time for the `fuser` command to run.
+
+If all of this sounds like too much work, just use `npm run start` and restart the server manually with Ctrl-C.

--- a/nodemon.json
+++ b/nodemon.json
@@ -1,0 +1,7 @@
+{
+  "events": {
+    "restart": "sudo fuser -k 8080/tcp",
+    "crash": "sudo fuser -k 8080/tcp"
+  },
+  "delay": "750"
+}

--- a/src/server.js
+++ b/src/server.js
@@ -360,6 +360,7 @@ function encodeAddress(address) {
   return formattedAddress;
 }
 
+// This number should be kept in sync with the port number in nodemon.json
 const port = 8080;
 const server = app.listen(port, () =>
   console.log(`Server listening on http://localhost:${port}`)


### PR DESCRIPTION
A small change that makes nodemon (the program responsible for auto-restarting the server on changes) work with socket.io.



