### PR TITLE
Keep user info

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -161,10 +161,16 @@ app.post(
   async (request, response) => {
     const { body, datastoreKey: key, event } = request;
     const [lat, long] = body.location;
-    const { name } = body;
+    const { name, address } = body;
     event.users = event.users || {};
     const userInfo = event.users[request.session.userID] || {};
-    event.users[request.session.userID] = { ...userInfo, name, lat, long };
+    event.users[request.session.userID] = {
+      ...userInfo,
+      name,
+      lat,
+      long,
+      address,
+    };
     datastore
       // Datastore attaches a "symbol" (https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Symbol)
       // to any entities returned from a query. We don't want to store this attached metadata back into the database

--- a/static/absolute/js/searchPage.js
+++ b/static/absolute/js/searchPage.js
@@ -50,6 +50,7 @@ window.onload = function () {
         headers: window.HEADER_CONTENT_TYPE_JSON,
         body: JSON.stringify({
           name,
+          address,
           location: [lat, long],
         }),
       });
@@ -66,8 +67,6 @@ window.onload = function () {
       alert("error posting to api");
       return;
     }
-    nameInput.value = "";
-    addressInput.value = "";
   });
 
   document.getElementById("participants-btn").addEventListener("click", () => {
@@ -110,6 +109,13 @@ socket.on("refresh", () => {
 
 async function refreshUI() {
   const eventId = getEventId();
+
+  fetch(`/api/${eventId}/me`)
+    .then((response) => response.json())
+    .then(({ data: { name, address } = {} }) => {
+      document.getElementById("name-input").value = name ? name : "";
+      document.getElementById("address-input").value = address ? address : "";
+    });
 
   let failure = false;
   let map = null;


### PR DESCRIPTION
Keep user info when submitting. Now after hitting search, or when refreshing the page, users will still see their existing information.